### PR TITLE
Sependa repo migration 

### DIFF
--- a/SalesforceSDKCore-Taptera.podspec
+++ b/SalesforceSDKCore-Taptera.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name = "SalesforceSDKCore-Taptera"
-  s.version = "2.3.1"
-  s.summary = "Taptera version of Salesforce SDK Core for iOS."
-  s.homepage = "https://github.com/Taptera/SalesforceSDKCore-Taptera"
+  s.version = "2.3.2"
+  s.summary = "Sependa version of Salesforce SDK Core for iOS."
+  s.homepage = "https://github.com/Sependa/SalesforceSDKCore-Taptera"
   s.license      = {:type => 'custom', :file => 'LICENSE.md'}
   s.author = 'Salesforce'
-  s.source = { :git => "https://github.com/Taptera/SalesforceSDKCore-Taptera.git", :tag => "v#{s.version}" }
+  s.source = { :git => "https://github.com/Sependa/SalesforceSDKCore-Taptera.git", :tag => "v#{s.version}" }
   s.platform  = :ios, '6.0'
 
   s.requires_arc = true


### PR DESCRIPTION
What's up:
- updated repo links to Sependa
- bumped version to 2.3.2

---

```
pod lib lint --sources='https://github.com/Sependa/cocoapods-specs,https://github.com/CocoaPods/Specs'  --allow-warnings --use-libraries

 -> SalesforceSDKCore-Taptera (2.3.2)
    - WARN  | xcodebuild:  MKNetworkKit-Salesforce-Taptera/MKNetworkKit/MKNetworkOperation.m:1300:27: warning: 'kSecTrustResultConfirm' is deprecated [-Wdeprecated-declarations]
    - NOTE  | xcodebuild:  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.3.sdk/System/Library/Frameworks/Security.framework/Headers/SecTrust.h:87:5: note: 'kSecTrustResultConfirm' has been explicitly marked deprecated here
    - WARN  | [iOS] xcodebuild:  MKNetworkKit-Salesforce-Taptera/MKNetworkKit/MKNetworkOperation.m:1353:34: warning: implicit conversion loses integer precision: 'const long long' to 'NSUInteger' (aka 'unsigned int') [-Wshorten-64-to-32]
    - WARN  | [iOS] xcodebuild:  MKNetworkKit-Salesforce-Taptera/MKNetworkKit/MKNetworkOperation.m:1502:12: warning: initialization of pointer of type 'NSCachedURLResponse * _Nullable' to null from a constant boolean expression [-Wbool-conversion]
    - WARN  | [iOS] xcodebuild:  SalesforceSecurity-Taptera/SalesforceSecurity/Classes/SFKeyStoreManager.m:93:123: warning: enum values with underlying type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead [-Wformat]
    - WARN  | [iOS] xcodebuild:  SalesforceSecurity-Taptera/SalesforceSecurity/Classes/SFKeyStoreManager.m:153:123: warning: enum values with underlying type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead [-Wformat]
    - WARN  | [iOS] xcodebuild:  SalesforceSecurity-Taptera/SalesforceSecurity/Classes/SFKeyStoreManager.m:265:123: warning: enum values with underlying type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead [-Wformat]
    - WARN  | xcodebuild:  SalesforceOAuth-Taptera/SalesforceOAuth/Classes/SFOAuthCoordinator.m:300:29: warning: implicit conversion from enumeration type 'enum NSURLCacheStoragePolicy' to different enumeration type 'NSURLRequestCachePolicy' (aka 'enum NSURLRequestCachePolicy') [-Wenum-conversion]
    - WARN  | xcodebuild:  SalesforceOAuth-Taptera/SalesforceOAuth/Classes/SFOAuthCoordinator.m:386:39: warning: undeclared selector 'objectWithData:' [-Wundeclared-selector]
    - WARN  | xcodebuild:  SalesforceOAuth-Taptera/SalesforceOAuth/Classes/SFOAuthCoordinator.m:387:41: warning: undeclared selector 'objectWithString:' [-Wundeclared-selector]
    - WARN  | [iOS] xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceSDKCore-Taptera/SalesforceSDKCore/Classes/SmartStore/SFAlterSoupLongOperation.m:75:22: warning: incompatible pointer to integer conversion assigning to 'BOOL' (aka 'signed char') from 'id _Nullable' [-Wint-conversion]
    - WARN  | [iOS] xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceSDKCore-Taptera/SalesforceSDKCore/Classes/SmartStore/SFAlterSoupLongOperation.m:266:12: warning: implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'long' [-Wshorten-64-to-32]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceSDKCore-Taptera/SalesforceSDKCore/Classes/Security/SFCommunityData.h:41:41: warning: auto property synthesis will not synthesize property 'description' because it is 'readwrite' but it will be synthesized 'readonly' via another property [-Wobjc-property-synthesis]
    - NOTE  | xcodebuild:  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.3.sdk/usr/include/objc/NSObject.h:43:38: note: property declared here
    - WARN  | [iOS] xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceSDKCore-Taptera/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.m:820:45: warning: implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'long' [-Wshorten-64-to-32]
    - WARN  | [iOS] xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceSDKCore-Taptera/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.m:1196:56: warning: implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'NSInteger' (aka 'int') [-Wshorten-64-to-32]
    - WARN  | [iOS] xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceSDKCore-Taptera/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.m:1392:12: warning: implicit conversion loses integer precision: 'unsigned long long _Nullable' to 'long' [-Wshorten-64-to-32]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceSDKCore-Taptera/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreInspectorViewController.m:233:21: warning: assigning to 'id<UINavigationBarDelegate> _Nullable' from incompatible type 'SFSmartStoreInspectorViewController *const __strong'

SalesforceSDKCore-Taptera passed validation.
```
